### PR TITLE
Clarify permission warning messages in shell.nix

### DIFF
--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -1,61 +1,49 @@
 # This module defines a standard configuration for NixOS shells.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 with lib;
-
-let
-
-  cfg = config.environment;
-
-in
 
 {
 
   config = {
 
-    environment.shellAliases =
-      { ls = "ls --color=tty";
-        ll = "ls -l";
-        l  = "ls -alh";
-      };
-
     environment.shellInit =
       ''
         # Set up the per-user profile.
-        mkdir -m 0755 -p $NIX_USER_PROFILE_DIR
-        if test "$(stat --printf '%u' $NIX_USER_PROFILE_DIR)" != "$(id -u)"; then
-            echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
+        mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
+        if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
+            echo "WARNING: the user profile dir $NIX_USER_PROFILE_DIR should belong to user id $(id -u)" >&2
         fi
 
-        if test -w $HOME; then
-          if ! test -L $HOME/.nix-profile; then
-              if test "$USER" != root; then
-                  ln -s $NIX_USER_PROFILE_DIR/profile $HOME/.nix-profile
+        if [ -w "$HOME" ]; then
+          if ! [ -L "$HOME/.nix-profile" ]; then
+              if [ "$USER" != root ]; then
+                  ln -s "$NIX_USER_PROFILE_DIR/profile" "$HOME/.nix-profile"
               else
                   # Root installs in the system-wide profile by default.
-                  ln -s /nix/var/nix/profiles/default $HOME/.nix-profile
+                  ln -s /nix/var/nix/profiles/default "$HOME/.nix-profile"
               fi
           fi
 
           # Subscribe the root user to the NixOS channel by default.
-          if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
-              echo "${config.system.defaultChannel} nixos" > $HOME/.nix-channels
+          if [ "$USER" = root -a ! -e "$HOME/.nix-channels" ]; then
+              echo "${config.system.defaultChannel} nixos" > "$HOME/.nix-channels"
           fi
 
           # Create the per-user garbage collector roots directory.
-          NIX_USER_GCROOTS_DIR=/nix/var/nix/gcroots/per-user/$USER
-          mkdir -m 0755 -p $NIX_USER_GCROOTS_DIR
-          if test "$(stat --printf '%u' $NIX_USER_GCROOTS_DIR)" != "$(id -u)"; then
-              echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
+          NIX_USER_GCROOTS_DIR="/nix/var/nix/gcroots/per-user/$USER"
+          mkdir -m 0755 -p "$NIX_USER_GCROOTS_DIR"
+          if [ "$(stat --printf '%u' "$NIX_USER_GCROOTS_DIR")" != "$(id -u)" ]; then
+              echo "WARNING: the per-user gcroots dir $NIX_USER_GCROOTS_DIR should belong to user id $(id -u)" >&2
           fi
 
           # Set up a default Nix expression from which to install stuff.
-          if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
-              rm -f $HOME/.nix-defexpr
-              mkdir -p $HOME/.nix-defexpr
+          if [ ! -e "$HOME/.nix-defexpr" -o -L "$HOME/.nix-defexpr" ]; then
+              rm -f "$HOME/.nix-defexpr"
+              mkdir -p "$HOME/.nix-defexpr"
               if [ "$USER" != root ]; then
-                  ln -s /nix/var/nix/profiles/per-user/root/channels $HOME/.nix-defexpr/channels_root
+                  ln -s /nix/var/nix/profiles/per-user/root/channels "$HOME/.nix-defexpr/channels_root"
               fi
           fi
         fi


### PR DESCRIPTION
###### Motivation for this change

The original message confused me into `chown 1000 [folder]`, which was quite the wrong thing to do. 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Change is trivial.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

